### PR TITLE
[zlib] Update to 1.3. JB#61263

### DIFF
--- a/rpm/backport-Reject-overflows-of-zip-header-fields-in-minizip.patch
+++ b/rpm/backport-Reject-overflows-of-zip-header-fields-in-minizip.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Hans Wennborg <hans@chromium.org>
+Date: Fri, 18 Aug 2023 11:05:33 +0200
+Subject: [PATCH] Reject overflows of zip header fields in minizip.
+
+This checks the lengths of the file name, extra field, and comment
+that would be put in the zip headers, and rejects them if they are
+too long. They are each limited to 65535 bytes in length by the zip
+format. This also avoids possible buffer overflows if the provided
+fields are too long.
+---
+ contrib/minizip/zip.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/contrib/minizip/zip.c b/contrib/minizip/zip.c
+index 3d3d4caddefc6b70542c76941a23ec4b5b5153f4..0446109b268253023ab58679b935167f87f02f9f 100644
+--- a/contrib/minizip/zip.c
++++ b/contrib/minizip/zip.c
+@@ -1043,6 +1043,17 @@ extern int ZEXPORT zipOpenNewFileInZip4_64(zipFile file, const char* filename, c
+       return ZIP_PARAMERROR;
+ #endif
+ 
++    // The filename and comment length must fit in 16 bits.
++    if ((filename!=NULL) && (strlen(filename)>0xffff))
++        return ZIP_PARAMERROR;
++    if ((comment!=NULL) && (strlen(comment)>0xffff))
++        return ZIP_PARAMERROR;
++    // The extra field length must fit in 16 bits. If the member also requires
++    // a Zip64 extra block, that will also need to fit within that 16-bit
++    // length, but that will be checked for later.
++    if ((size_extrafield_local>0xffff) || (size_extrafield_global>0xffff))
++        return ZIP_PARAMERROR;
++
+     zi = (zip64_internal*)file;
+ 
+     if (zi->in_opened_file_inzip == 1)

--- a/rpm/zlib.spec
+++ b/rpm/zlib.spec
@@ -4,11 +4,12 @@ Name:       zlib
 %define keepstatic 1
 
 Summary:    The zlib compression and decompression library
-Version:    1.2.13
+Version:    1.3
 Release:    1
 License:    zlib and Boost
 URL:        https://github.com/sailfishos/zlib
 Source0:    %{name}-%{version}.tar.gz
+Patch0:     backport-Reject-overflows-of-zip-header-fields-in-minizip.patch
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 BuildRequires:  automake
@@ -67,60 +68,21 @@ Man pages and other documentation for %{name} and minizip.
 
 
 %prep
-%setup -q -n %{name}-%{version}/upstream
+%autosetup -p1 -n %{name}-%{version}/upstream
 
 %build
-%ifarch  %{arm}
-export CFLAGS="$RPM_OPT_FLAGS -mfpu=neon"
-%else
-export CFLAGS="$RPM_OPT_FLAGS"
-%endif
-
+export CFLAGS="$RPM_OPT_FLAGS -fPIC"
+export LDFLAGS="$LDFLAGS -Wl,-z,relro -Wl,-z,now"
 ./configure --libdir=%{_libdir} --includedir=%{_includedir} --prefix=%{_prefix}
 
-#ensure 64 offset versions are compiled (do not override CFLAGS blindly)
-export CFLAGS="`grep -E ^CFLAGS Makefile | sed -e 's/CFLAGS=//'`"
-export SFLAGS="`grep -E ^SFLAGS Makefile | sed -e 's/SFLAGS=//'`"
+%make_build
 
-#
-# first,build with -fprofile-generate to create the profile data
-#
-make %{?_smp_mflags} CFLAGS="$CFLAGS -pg -fprofile-generate" SFLAGS="$SFLAGS -pg -fprofile-generate"
-
-#
-# Then run some basic operations using the minigzip test program
-# to collect the profile guided stats
-# (in this case, we compress and decompress the content of /usr/bin)
-#
-cp Makefile Makefile.old
-make test -f Makefile.old LDFLAGS="libz.a -lgcov"
-cat /usr/bin/* | ./minigzip | ./minigzip -d &> /dev/null
-
-#
-# Now that we have the stats, we need to build again, using -fprofile-use
-# Due to the libtool funnies, we need to hand copy the profile data to .libs
-#
-mkdir libs-tmp
-cp *gcda libs-tmp
-make clean
-mv libs-tmp/*gcda .
-rm -rf libs-tmp
-
-#
-# Final build, with -fprofile-use
-#
-
-%ifarch %{ix86} x86_64
-make %{?_smp_mflags} CFLAGS="$CFLAGS -DHAVE_BINUTILS=%{binutils_ver}"  SFLAGS="$SFLAGS " adler32.o adler32.lo
-%endif
-make %{?_smp_mflags} CFLAGS="$CFLAGS -fprofile-use -DHAVE_BINUTILS=%{binutils_ver}"  SFLAGS="$SFLAGS -fprofile-use"
-cd contrib/minizip
-%reconfigure --disable-static
-export CFLAGS="$RPM_OPT_FLAGS -DHAVE_BINUTILS=%{binutils_ver}"
-make %{?_smp_mflags}
+pushd contrib/minizip
+%reconfigure --enable-static=no
+%make_build
+popd
 
 %install
-rm -rf %{buildroot}
 %make_install
 
 mkdir -p $RPM_BUILD_ROOT%{_docdir}/%{name}-%{version}
@@ -129,10 +91,13 @@ install -m0644 -t $RPM_BUILD_ROOT%{_docdir}/%{name}-%{version} \
         contrib/minizip/MiniZip64_info.txt \
         contrib/minizip/MiniZip64_Changes.txt
 
-cd contrib/minizip
-make install DESTDIR=$RPM_BUILD_ROOT
+pushd contrib/minizip
+%make_install
+# https://github.com/madler/zlib/pull/229
+rm $RPM_BUILD_ROOT%_includedir/minizip/crypt.h
 
-rm $RPM_BUILD_ROOT%{_libdir}/*.la
+find $RPM_BUILD_ROOT -name '*.la' -delete
+popd
 
 %check
 make test


### PR DESCRIPTION
Backport security fix from upstream development branch. Cleanup spec based on Fedora spec.